### PR TITLE
Product number emulator fix

### DIFF
--- a/disruptive/resources/device.py
+++ b/disruptive/resources/device.py
@@ -71,7 +71,6 @@ class Device(dtoutputs.OutputBase):
         self.device_id: str = device['name'].split('/')[-1]
         self.project_id: str = device['name'].split('/')[1]
         self.device_type: str = device['type']
-        self.product_number: str = device['productNumber']
         self.labels: dict = device['labels']
 
         # Set display_name if `name` label key exists.
@@ -84,6 +83,12 @@ class Device(dtoutputs.OutputBase):
             self.is_emulated = True
         else:
             self.is_emulated = False
+
+        # If it exists, set the product number.
+        # This is not present for emulated devices.
+        self.product_number: str = ''
+        if 'productNumber' in device:
+            self.product_number = device['productNumber']
 
         # If it exists, set the reported object.
         self.reported = None

--- a/tests/api_responses.py
+++ b/tests/api_responses.py
@@ -303,7 +303,6 @@ touch_count_sensor = {
 null_reported_sensor = {
     "name": "projects/c0md3mmpc7bet3vico8g/devices/emuc1pe9nvlq0bgk44sg4o0",
     "type": "temperature",
-    "productNumber": "",
     "labels": {
         "name": "Emulated temperature: emuc16e9nvlq0bgk44sg4o0",
         "virtual-sensor": ""

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -343,3 +343,25 @@ class TestDevice():
             disruptive.Device.get_device('device_id', 'project_id')
 
             assert warning_mock.call_count == 1
+
+    def test_missing_product_number(self, request_mock):
+        # Update the response data with device data.
+        request_mock.json = dtapiresponses.null_reported_sensor
+
+        # Call Device.get_device() method.
+        d = disruptive.Device.get_device('device_id', 'project_id')
+
+        # Verify expected outgoing parameters in request.
+        request_mock.assert_requested(
+            method='GET',
+            url=disruptive.base_url+'/projects/project_id/devices/device_id',
+        )
+
+        # Assert single request sent.
+        request_mock.assert_request_count(1)
+
+        # Assert instance of Device object.
+        assert isinstance(d, disruptive.Device)
+
+        # Assert empty string as product number.
+        assert d.product_number == ''


### PR DESCRIPTION
Fixed a bug where the Device constructor crashed when the emulator API does not return a productNumber field.