### PR TITLE
Log recursion fix

### DIFF
--- a/disruptive/logging.py
+++ b/disruptive/logging.py
@@ -49,7 +49,7 @@ def _log_flag_exceeds(level: str | dict) -> bool:
         return False
 
     # Verify set value is valid.
-    if disruptive.log_level not in levels:
+    if disruptive.log_level.lower() not in levels:
         # As an invalid log_level has been provided, reset it
         # to default before raising the exception.
         disruptive.log_level = "info"
@@ -61,7 +61,7 @@ def _log_flag_exceeds(level: str | dict) -> bool:
         )
 
     # Check if level is exceeded.
-    if levels[level] >= levels[disruptive.log_level]:
+    if levels[level] >= levels[disruptive.log_level.lower()]:
         return True
     else:
         return False

--- a/disruptive/logging.py
+++ b/disruptive/logging.py
@@ -50,6 +50,10 @@ def _log_flag_exceeds(level: str | dict) -> bool:
 
     # Verify set value is valid.
     if disruptive.log_level not in levels:
+        # As an invalid log_level has been provided, reset it
+        # to default before raising the exception.
+        disruptive.log_level = "info"
+
         raise dterrors.ConfigurationError(
             'Invalid logging level {}. '
             'Must be either None, "debug", "info", '

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,7 +1,9 @@
+import pytest
 from unittest.mock import patch
 
 import disruptive
 import disruptive.logging as dtlog
+import disruptive.errors as dterrors
 
 
 class TestLogging():
@@ -82,4 +84,32 @@ class TestLogging():
             warning=False,
             error=False,
         )
+        disruptive.log_level = None
+
+    def test_case_insensitive(self):
+        disruptive.log_level = "CRITICAL"
+        self._check_level_called(
+            msg='Test message.',
+            debug=False,
+            info=False,
+            warning=False,
+            error=False,
+        )
+        disruptive.log_level = None
+
+    def test_invalid_level_reset(self):
+        disruptive.log_level = "SOME_INVALID_STRING"
+        with pytest.raises(dterrors.ConfigurationError):
+            self._check_level_called(
+                msg='Test message.',
+                debug=False,
+                info=False,
+                warning=False,
+                error=False,
+                critical=False,
+            )
+
+            # Log level should be reset to default.
+            assert disruptive.log_level == 'info'
+
         disruptive.log_level = None


### PR DESCRIPTION
- fix: resetting `log_level` before raising an exception for invalid level.
- feat: `log_level` is now case-insensitive.
- chore: a few tests reflecting bugfix.