### PR TITLE
Co2 emulator events

### DIFF
--- a/disruptive/resources/device.py
+++ b/disruptive/resources/device.py
@@ -31,8 +31,8 @@ class Device(dtoutputs.OutputBase):
         The product number of the device.
     labels : dict
         Label keys and values.
-    is_emulator : bool
-        True if the device is an emulator, otherwise False.
+    is_emulated : bool
+        True if the device is emulated, otherwise False.
     reported : Reported
         Object containing the data from the most recent events.
 

--- a/disruptive/resources/emulator.py
+++ b/disruptive/resources/emulator.py
@@ -129,7 +129,9 @@ class Emulator():
                       disruptive.events.BatteryStatus |
                       disruptive.events.ConnectionStatus |
                       disruptive.events.EthernetStatus |
-                      disruptive.events.CellularStatus,
+                      disruptive.events.CellularStatus |
+                      disruptive.events.Co2 |
+                      disruptive.events.Pressure,
                       **kwargs: Any,
                       ) -> None:
         """


### PR DESCRIPTION
- The new `Co2`- and `Pressure` events were missing in `dt.Emulator.publish_event()` typing.
- Fixed some tiny docstring errors.