### PR TITLE
added more members to disruptive module

### DIFF
--- a/disruptive/__init__.py
+++ b/disruptive/__init__.py
@@ -20,6 +20,8 @@ from disruptive.resources.emulator import Emulator  # noqa
 
 # Additional helper modules.
 import disruptive.events as events  # noqa
+import disruptive.outputs as outputs  # noqa
+import disruptive.errors as errors  # noqa
 
 # If set, logs of chosen level and higher are printed to console.
 # Available levels are: debug, info, warning, error, critical.


### PR DESCRIPTION
While it works just fine right now, modern linters will (correctly) complain about the `disruptive` module missing members when trying to access helper classes like errors like in the example below.

```python
try:
    # ...
except dt.errors.BadRequest:  # <- Missing member `errors`
    pass
```