### PR TITLE
project.id attribute deprecated

### DIFF
--- a/disruptive/resources/project.py
+++ b/disruptive/resources/project.py
@@ -15,7 +15,7 @@ class Project(OutputBase):
 
     Attributes
     ----------
-    id : str
+    project_id : str
         Unique project ID.
     display_name : str
         The provided display name.
@@ -47,7 +47,8 @@ class Project(OutputBase):
         OutputBase.__init__(self, project)
 
         # Unpack attributes from dictionary.
-        self.id: str = project['name'].split('/')[-1]
+        self.project_id: str = project['name'].split('/')[-1]
+        self.id: str = self.project_id  # Deprecated in favor of project_id.
         self.display_name: str = project['displayName']
         self.organization_id: str = project['organization'].split('/')[-1]
         self.organization_display_name: str = \

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -28,7 +28,7 @@ class TestProject():
         p = disruptive.Project.get_project('project_id')
 
         # Assert attributes unpacked correctly.
-        assert p.id == res['name'].split('/')[-1]
+        assert p.project_id == res['name'].split('/')[-1]
         assert p.display_name == res['displayName']
         assert p.organization_id == res['organization'].split('/')[-1]
         assert p.organization_display_name == res['organizationDisplayName']


### PR DESCRIPTION
Attribute `Project.id` deprecated in favor of `Project.project_id` for consistency with other resources. `Project.id` will still be available, though undocumented.