### PR TITLE
Stream retry policy

### DIFF
--- a/disruptive/errors.py
+++ b/disruptive/errors.py
@@ -283,8 +283,12 @@ def parse_request_error(caught_error: Exception,
 
     """
 
+    # Disruptive ConnectionErrors should always retry.
+    if isinstance(caught_error, ConnectionError):
+        return caught_error, True, nth_attempt**2
+
     # Read Timeouts should be attempted again.
-    if isinstance(caught_error, requests.exceptions.ReadTimeout):
+    elif isinstance(caught_error, requests.exceptions.ReadTimeout):
         return (
             ReadTimeout('Connection timed out.'),
             True,

--- a/disruptive/errors.py
+++ b/disruptive/errors.py
@@ -334,8 +334,15 @@ def parse_api_status_code(status_code: Optional[int],
 
     """
 
+    # If not status code is provided, assume it *couldn't* be
+    # set due to an internal error.
+    if status_code is None:
+        status_code = 500
+
     # Check for API errors.
-    if status_code == 200:
+    if status_code < 100:
+        return InternalServerError(data), True, nth_attempt**2
+    elif status_code == 200:
         return None, False, None
     elif status_code == 400:
         return BadRequest(data), False, None

--- a/disruptive/errors.py
+++ b/disruptive/errors.py
@@ -283,12 +283,8 @@ def parse_request_error(caught_error: Exception,
 
     """
 
-    # Disruptive ConnectionErrors should always retry.
-    if isinstance(caught_error, ConnectionError):
-        return caught_error, True, nth_attempt**2
-
     # Read Timeouts should be attempted again.
-    elif isinstance(caught_error, requests.exceptions.ReadTimeout):
+    if isinstance(caught_error, requests.exceptions.ReadTimeout):
         return (
             ReadTimeout('Connection timed out.'),
             True,

--- a/disruptive/requests.py
+++ b/disruptive/requests.py
@@ -347,8 +347,9 @@ class DTRequest():
                 break
 
             except Exception as e:
-                error, should_retry, sleeptime = dterrors.parse_request_error(
-                    e, {}, nth_attempt)
+                # ConnectionErrors should always be retried.
+                result = dterrors.parse_request_error(e, {}, nth_attempt)
+                error, should_retry, sleeptime = result
 
                 # Print the error and try again up to max_request_attempts.
                 if nth_attempt < request_attempts and should_retry:

--- a/disruptive/requests.py
+++ b/disruptive/requests.py
@@ -334,13 +334,13 @@ class DTRequest():
                         raise dterrors.UnknownError(payload)
 
                 # If the stream finished, but without an error, break the loop.
-                dtlog.info('Stream ended without an error.')
-                break
+                msg = 'Stream ended without an error.'
+                raise dterrors.ConnectionError(msg)
 
             except KeyboardInterrupt:
                 break
 
-            except requests.exceptions.RequestException as e:
+            except Exception as e:
                 error, should_retry, sleeptime = dterrors.parse_request_error(
                     e, {}, nth_attempt)
 

--- a/disruptive/requests.py
+++ b/disruptive/requests.py
@@ -98,6 +98,9 @@ class DTRequest():
         # Add custom user agent.
         headers['User-Agent'] = USER_AGENT
 
+        # Define default response values.
+        res = None
+
         # Attempt to send the request.
         try:
             # Use the requests package to send the request.
@@ -119,7 +122,10 @@ class DTRequest():
             return DTResponse({}, None, {}), e
         except ValueError as e:
             # Requests' .json() fails when no json is returned (code 405).
-            return DTResponse({}, res.status_code, res.headers), e
+            if res is None:
+                return DTResponse({}, 0, {}), e
+            else:
+                return DTResponse({}, res.status_code, res.headers), e
 
     def _send_request(self, nth_attempt: int = 1) -> dict:
         """

--- a/tests/framework.py
+++ b/tests/framework.py
@@ -26,6 +26,9 @@ class RequestsReponseMock():
             else:
                 yield d
 
+        # In order to stop stream in the tests, raise KeyboardInterrupt.
+        raise KeyboardInterrupt
+
 
 class RequestMock():
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -13,8 +13,12 @@ from disruptive.events import Event
 class TestStream():
 
     def test_event_stream_arguments(self, request_mock):
+        request_mock.iter_data = [
+            dtapiresponses.stream_temperature_event
+        ]
+
         # Call stream with customer kwargs.
-        for event in disruptive.Stream.event_stream(
+        for _ in disruptive.Stream.event_stream(
             project_id='project_id',
             device_ids=['id1', 'id2', 'id3'],
             label_filters={
@@ -55,7 +59,7 @@ class TestStream():
 
         # Mock logging function, which should trigger once for each ping.
         with patch('disruptive.logging.debug') as log_mock:
-            for event in disruptive.Stream.event_stream('project_id'):
+            for _ in disruptive.Stream.event_stream('project_id'):
                 pass
 
             # Assert logging called with expected message.
@@ -99,7 +103,7 @@ class TestStream():
         # Catch ConnectionError caused by exhausted retries.
         with pytest.raises(dterrors.ReadTimeout):
             # Start a stream, which should rause an error causing retries.
-            for event in disruptive.Stream.event_stream(
+            for _ in disruptive.Stream.event_stream(
                     project_id='project_id',
                     request_attempts=8):
                 pass
@@ -117,7 +121,7 @@ class TestStream():
         # Catch ConnectionError caused by exhausted retries.
         with pytest.raises(dterrors.ConnectionError):
             # Start a stream, which should rause an error causing retries.
-            for event in disruptive.Stream.event_stream(
+            for _ in disruptive.Stream.event_stream(
                     project_id='project_id',
                     request_attempts=7):
                 pass


### PR DESCRIPTION
Stream retry policy will now catch errors thrown by gRPC which were before categorized as `UnknownError`.