### PR TITLE
Retry policy Refinement

### DIFF
--- a/disruptive/__init__.py
+++ b/disruptive/__init__.py
@@ -35,4 +35,4 @@ emulator_base_url = 'https://emulator.disruptive-technologies.com/v2'
 # worth considering, these variable determine how long to wait without an
 # answer, and how many times the package should retry before raising an error.
 request_timeout = 3  # seconds
-request_attempts = 5  # attempts
+request_attempts = 3  # attempts

--- a/disruptive/errors.py
+++ b/disruptive/errors.py
@@ -283,8 +283,12 @@ def parse_request_error(caught_error: Exception,
 
     """
 
+    # Disruptive ConnectionErrors should always retry.
+    if isinstance(caught_error, ConnectionError):
+        return caught_error, True, nth_attempt**2
+
     # Read Timeouts should be attempted again.
-    if isinstance(caught_error, requests.exceptions.ReadTimeout):
+    elif isinstance(caught_error, requests.exceptions.ReadTimeout):
         return (
             ReadTimeout('Connection timed out.'),
             True,

--- a/disruptive/errors.py
+++ b/disruptive/errors.py
@@ -334,8 +334,15 @@ def parse_api_status_code(status_code: Optional[int],
 
     """
 
+    # If not status code is provided, assume it *couldn't* be
+    # set due to an internal error.
+    if status_code is None:
+        status_code = 500
+
     # Check for API errors.
-    if status_code == 200:
+    if status_code < 100:
+        return InternalServerError(data), True, nth_attempt**2
+    elif status_code == 200:
         return None, False, None
     elif status_code == 400:
         return BadRequest(data), False, None

--- a/disruptive/errors.py
+++ b/disruptive/errors.py
@@ -283,12 +283,8 @@ def parse_request_error(caught_error: Exception,
 
     """
 
-    # Disruptive ConnectionErrors should always retry.
-    if isinstance(caught_error, ConnectionError):
-        return caught_error, True, nth_attempt**2
-
     # Read Timeouts should be attempted again.
-    elif isinstance(caught_error, requests.exceptions.ReadTimeout):
+    if isinstance(caught_error, requests.exceptions.ReadTimeout):
         return (
             ReadTimeout('Connection timed out.'),
             True,

--- a/disruptive/requests.py
+++ b/disruptive/requests.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 import time
 import json
 from typing import Optional, Any, Generator
@@ -127,7 +128,7 @@ class DTRequest():
             else:
                 return DTResponse({}, res.status_code, res.headers), e
 
-    def _send_request(self, nth_attempt: int = 1) -> dict:
+    def _send_request(self, nth_attempt: int = 0) -> dict:
         """
         Combines all the information and sends a request.
 
@@ -179,14 +180,13 @@ class DTRequest():
 
         # Check if retry is required.
         if should_retry and nth_attempt < self.request_attempts:
-            dtlog.error(error)
             dtlog.warning('Reconnecting in {}s.'.format(sleeptime))
 
             # Sleep if necessary.
             if sleeptime is not None:
                 time.sleep(sleeptime)
 
-            dtlog.info('Connection attempt {}/{}.'.format(
+            dtlog.info('Connection attempt {} of {}.'.format(
                 nth_attempt+1,
                 self.request_attempts,
             ))
@@ -281,19 +281,19 @@ class DTRequest():
         # Add ping parameter to dictionary.
         params['ping_interval'] = str(PING_INTERVAL) + 's'
 
-        # If provided, override package-wide auth with argument.
-        if 'auth' in kwargs:
-            headers['Authorization'] = kwargs['auth'].get_token()
-        else:
-            headers['Authorization'] = dt.default_auth.get_token()
-
         # Add custom user agent.
         headers['User-Agent'] = USER_AGENT
 
         # Set up a simple catch-all retry policy.
-        nth_attempt = 1
+        nth_attempt = 0
         while True:
             try:
+                # Set the authorization header each retry in case we expire.
+                if 'auth' in kwargs:
+                    headers['Authorization'] = kwargs['auth'].get_token()
+                else:
+                    headers['Authorization'] = dt.default_auth.get_token()
+
                 # Set up a stream connection.
                 # Connection will timeout and reconnect if no single event
                 # is received in an interval of ping_interval + ping_jitter.
@@ -318,7 +318,7 @@ class DTRequest():
                     payload = json.loads(line)
                     if 'result' in payload:
                         # Reset retry counter.
-                        nth_attempt = 1
+                        nth_attempt = 0
 
                         # Check for ping event.
                         event = payload['result']['event']
@@ -346,14 +346,13 @@ class DTRequest():
             except KeyboardInterrupt:
                 break
 
-            except Exception as e:
-                # ConnectionErrors should always be retried.
-                result = dterrors.parse_request_error(e, {}, nth_attempt)
-                error, should_retry, sleeptime = result
+            except dterrors.DTApiError as e:
+                # Except for Unauthorized, retry all DTApiErrors.
+                if isinstance(e, dterrors.Unauthorized):
+                    raise e
+                elif nth_attempt < request_attempts:
+                    sleeptime = nth_attempt**2
 
-                # Print the error and try again up to max_request_attempts.
-                if nth_attempt < request_attempts and should_retry:
-                    dtlog.error(error)
                     dtlog.warning('Reconnecting in {}s.'.format(sleeptime))
 
                     # Exponential backoff in sleep time.
@@ -361,13 +360,40 @@ class DTRequest():
 
                     # Iterate attempt counter.
                     nth_attempt += 1
-                    dtlog.info('Connection attempt {}/{}.'.format(
+                    dtlog.info('Connection attempt {} of {}.'.format(
+                        nth_attempt,
+                        request_attempts,
+                    ))
+                else:
+                    # To avoid printing the entire chain of re-raised
+                    # exceptions, limit the traceback.
+                    sys.tracebacklimit = 0
+                    raise e
+
+            except requests.exceptions.RequestException as e:
+                # ConnectionErrors should always be retried.
+                result = dterrors.parse_request_error(e, {}, nth_attempt)
+                error, should_retry, sleeptime = result
+
+                # Print the error and try again up to max_request_attempts.
+                if nth_attempt < request_attempts and should_retry:
+                    dtlog.warning('Reconnecting in {}s.'.format(sleeptime))
+
+                    # Exponential backoff in sleep time.
+                    time.sleep(sleeptime)
+
+                    # Iterate attempt counter.
+                    nth_attempt += 1
+                    dtlog.info('Connection attempt {} of {}.'.format(
                         nth_attempt,
                         request_attempts,
                     ))
 
                 else:
-                    raise error
+                    # To avoid printing the entire chain of re-raised
+                    # exceptions, limit the traceback.
+                    sys.tracebacklimit = 0
+                    raise error from e
 
 
 class DTResponse():

--- a/disruptive/requests.py
+++ b/disruptive/requests.py
@@ -347,8 +347,9 @@ class DTRequest():
                 break
 
             except Exception as e:
-                error, should_retry, sleeptime = dterrors.parse_request_error(
-                    e, {}, nth_attempt)
+                # ConnectionErrors should always be retried.
+                result = dterrors.parse_request_error(e, {}, nth_attempt)
+                error, should_retry, sleeptime = result
 
                 # Print the error and try again up to max_request_attempts.
                 if nth_attempt < request_attempts and should_retry:

--- a/disruptive/requests.py
+++ b/disruptive/requests.py
@@ -334,13 +334,13 @@ class DTRequest():
                         raise dterrors.UnknownError(payload)
 
                 # If the stream finished, but without an error, break the loop.
-                dtlog.info('Stream ended without an error.')
-                break
+                msg = 'Stream ended without an error.'
+                raise dterrors.ConnectionError(msg)
 
             except KeyboardInterrupt:
                 break
 
-            except requests.exceptions.RequestException as e:
+            except Exception as e:
                 error, should_retry, sleeptime = dterrors.parse_request_error(
                     e, {}, nth_attempt)
 

--- a/disruptive/requests.py
+++ b/disruptive/requests.py
@@ -98,6 +98,9 @@ class DTRequest():
         # Add custom user agent.
         headers['User-Agent'] = USER_AGENT
 
+        # Define default response values.
+        res = None
+
         # Attempt to send the request.
         try:
             # Use the requests package to send the request.
@@ -119,7 +122,10 @@ class DTRequest():
             return DTResponse({}, None, {}), e
         except ValueError as e:
             # Requests' .json() fails when no json is returned (code 405).
-            return DTResponse({}, res.status_code, res.headers), e
+            if res is None:
+                return DTResponse({}, 0, {}), e
+            else:
+                return DTResponse({}, res.status_code, res.headers), e
 
     def _send_request(self, nth_attempt: int = 1) -> dict:
         """

--- a/tests/framework.py
+++ b/tests/framework.py
@@ -26,6 +26,9 @@ class RequestsReponseMock():
             else:
                 yield d
 
+        # In order to stop stream in the tests, raise KeyboardInterrupt.
+        raise KeyboardInterrupt
+
 
 class RequestMock():
 

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -26,7 +26,7 @@ class TestResponseStatusCodes():
             dt.Device.get_device('', '')
 
         # 401 should retry once.
-        request_mock.assert_request_count(2)
+        request_mock.assert_request_count(3)
 
     def test_error_code_403(self, request_mock):
         # Set response status code to represent test.
@@ -78,7 +78,7 @@ class TestResponseStatusCodes():
             dt.Device.get_device('', '')
 
         # Assert expected retry attempts.
-        request_mock.assert_request_count(dt.request_attempts)
+        request_mock.assert_request_count(dt.request_attempts + 1)
 
     def test_error_code_503(self, request_mock):
         # Set response status code to represent test.
@@ -89,7 +89,7 @@ class TestResponseStatusCodes():
             dt.Device.get_device('', '')
 
         # Assert expected retry attempts.
-        request_mock.assert_request_count(dt.request_attempts)
+        request_mock.assert_request_count(dt.request_attempts + 1)
 
     def test_error_code_504(self, request_mock):
         # Set response status code to represent test.
@@ -100,7 +100,7 @@ class TestResponseStatusCodes():
             dt.Device.get_device('', '')
 
         # Assert expected retry attempts.
-        request_mock.assert_request_count(dt.request_attempts)
+        request_mock.assert_request_count(dt.request_attempts + 1)
 
     def test_server_error_group(self, request_mock):
         for code in [500, 503, 504]:

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -269,7 +269,7 @@ class TestRequests():
             )
 
         # Verify it did in fact retry that many times.
-        request_mock.assert_request_count(99)
+        request_mock.assert_request_count(100)
 
     def test_request_attempts_invalid(self, request_mock):
         # Catch expected error as retries are exhausted.

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -13,8 +13,12 @@ from disruptive.events import Event
 class TestStream():
 
     def test_event_stream_arguments(self, request_mock):
+        request_mock.iter_data = [
+            dtapiresponses.stream_temperature_event
+        ]
+
         # Call stream with customer kwargs.
-        for event in disruptive.Stream.event_stream(
+        for _ in disruptive.Stream.event_stream(
             project_id='project_id',
             device_ids=['id1', 'id2', 'id3'],
             label_filters={
@@ -55,7 +59,7 @@ class TestStream():
 
         # Mock logging function, which should trigger once for each ping.
         with patch('disruptive.logging.debug') as log_mock:
-            for event in disruptive.Stream.event_stream('project_id'):
+            for _ in disruptive.Stream.event_stream('project_id'):
                 pass
 
             # Assert logging called with expected message.
@@ -99,7 +103,7 @@ class TestStream():
         # Catch ConnectionError caused by exhausted retries.
         with pytest.raises(dterrors.ReadTimeout):
             # Start a stream, which should rause an error causing retries.
-            for event in disruptive.Stream.event_stream(
+            for _ in disruptive.Stream.event_stream(
                     project_id='project_id',
                     request_attempts=8):
                 pass
@@ -117,7 +121,7 @@ class TestStream():
         # Catch ConnectionError caused by exhausted retries.
         with pytest.raises(dterrors.ConnectionError):
             # Start a stream, which should rause an error causing retries.
-            for event in disruptive.Stream.event_stream(
+            for _ in disruptive.Stream.event_stream(
                     project_id='project_id',
                     request_attempts=7):
                 pass

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -109,7 +109,7 @@ class TestStream():
                 pass
 
         # Verify request is attempted the set number of times (+1).
-        request_mock.assert_request_count(8)
+        request_mock.assert_request_count(9)
 
     def test_retry_logic_connectionerror(self, request_mock):
         def side_effect_override(**kwargs):
@@ -127,4 +127,4 @@ class TestStream():
                 pass
 
         # Verify request is attempted the set number of times (+1).
-        request_mock.assert_request_count(7)
+        request_mock.assert_request_count(8)


### PR DESCRIPTION
Some updates to gRPC-gateway caused some problems with the existing streaming retry policy. This has been now been corrected, in addition to some other minor refinements.