### PR TITLE
Pep561 compliance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ coverage: venv
 	source ${VENV}/bin/activate && pytest --cov=disruptive tests/
 
 lint: venv
-	source ${VENV}/bin/activate && mypy disruptive/ && flake8 disruptive/
+	source ${VENV}/bin/activate && mypy --config-file ./mypy.ini disruptive/ && flake8 disruptive/
 
 clean:
 	rm -rf build/ dist/ pip-wheel-metadata/ *.egg-info

--- a/disruptive/outputs.py
+++ b/disruptive/outputs.py
@@ -27,7 +27,7 @@ class OutputBase(object):
 
         # Set attribute from input argument.
         self._raw = raw
-        self.raw: dict[str, str] = raw
+        self.raw: dict = raw
 
     def __repr__(self) -> str:
         return '{}.{}({})'.format(

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,7 +4,7 @@
 # Global options:
 
 [mypy]
-python_version = 3.9
+python_version = 3.7
 
 disallow_any_unimported = True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,11 @@ python_requires = >=3.7
 install_requires =
     requests >= 2.19.0, < 3.0.0
     pyjwt >= 2.0.0, < 3.0.0
+include-package-data = True
 packages = find:
+
+[options.package_data]
+disruptive = py.typed
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
- Type-checkers like MyPy will now assume we're PEP 561 compliant.
- I've updated MyPy to check based on Python 3.7. The rationale is that we should check for the oldest supported version to catch all errors as new features in typing is (should) be backward compatible.