### PR TITLE
experimental DataFrame support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ $(VENV)/bin/activate: setup.py
 	$(PIP) install --upgrade pip virtualenv
 	@test -d $(VENV) || $(PYTHON) -m virtualenv --clear $(VENV)
 	${VENV}/bin/python -m pip install --upgrade pip
-	${VENV}/bin/python -m pip install -e .[dev]
+	${VENV}/bin/python -m pip install -e .[dev,extra]
 
 build: venv
 	${VENV}/bin/python setup.py sdist bdist_wheel

--- a/disruptive/resources/eventhistory.py
+++ b/disruptive/resources/eventhistory.py
@@ -103,13 +103,16 @@ class EventHistory(list):
     def to_dataframe(self) -> Any:
         """
         Experimental function to convert a list of events to DataFrame.
+        Requires the installation of additional packages.
+        >> pip install disruptive[extra]
+
         The `pandas` package is not, and will not, be a dependency of
-        the core `disruptive` package, but this may be a way of adding
-        significant convenience to the output format for data-science use.
+        the core `disruptive` package. However, supporting DataFrames is a
+        significant enough convenience that we're experimenting with it here.
         May be removed in the future if we decide that this is not a good idea.
 
-        The columns `device_id`, `event_id`, and `event_type` is static, then
-        one additional column is added for every eventData field present.
+        The columns `device_id`, `event_id`, and `event_type` are static, then
+        one additional column is concatenated for every eventData field.
 
         Returns
         -------
@@ -126,7 +129,11 @@ class EventHistory(list):
         try:
             import pandas  # type: ignore
         except ModuleNotFoundError:
-            raise ModuleNotFoundError('Missing package `pandas`.')
+            raise ModuleNotFoundError(
+                'Missing package `pandas`.\n\n'
+                'to_dataframe() requires additional third-party packages.\n'
+                '>> pip install disruptive[extra]'
+            )
 
         rows = []
         for event in self:

--- a/disruptive/resources/eventhistory.py
+++ b/disruptive/resources/eventhistory.py
@@ -100,7 +100,7 @@ class EventHistory(list):
         # Return list of Event objects of paginated GET response.
         return EventHistory(Event.from_mixed_list(res))
 
-    def to_dataframe(self):
+    def to_dataframe(self) -> Any:
         """
         Experimental function to convert a list of events to DataFrame.
         The `pandas` package is not, and will not, be a dependency of
@@ -124,9 +124,9 @@ class EventHistory(list):
         """
 
         try:
-            import pandas
+            import pandas  # type: ignore
         except ModuleNotFoundError:
-            raise ModuleNotFoundError('Pandas not installed!')
+            raise ModuleNotFoundError('Missing package `pandas`.')
 
         rows = []
         for event in self:
@@ -150,5 +150,8 @@ class EventHistory(list):
             errors='ignore',
         )
 
-        return df
+        # Convert columns headers from camelCase to snake_case for consistency.
+        map = {name: dttrans.camel_to_snake_case(name) for name in df.columns}
+        df = df.rename(columns=map)
 
+        return df

--- a/disruptive/resources/eventhistory.py
+++ b/disruptive/resources/eventhistory.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 from typing import Optional, Any
 from datetime import datetime
 
+import disruptive
 import disruptive.requests as dtrequests
 import disruptive.transforms as dttrans
 from disruptive.events.events import Event
 
 
-class EventHistory():
+class EventHistory(list):
     """
-    Contains staticmethods for streaming events.
-    Used for namespacing only and thus does not have a constructor
+    Namespacing type of event history methods.
+    Inherits list, with some extra functionality.
 
     """
 
@@ -22,7 +23,7 @@ class EventHistory():
                     start_time: Optional[str | datetime] = None,
                     end_time: Optional[str | datetime] = None,
                     **kwargs: Any,
-                    ) -> list[Event]:
+                    ) -> EventHistory:
         """
         Get the event history for a single device.
 
@@ -47,7 +48,7 @@ class EventHistory():
 
         Returns
         -------
-        events : list[Event]
+        events : EventHistory[Event]
             A list of all events fetched by the call.
 
         Examples
@@ -97,5 +98,57 @@ class EventHistory():
         )
 
         # Return list of Event objects of paginated GET response.
-        events: list[Event] = Event.from_mixed_list(res)
-        return events
+        return EventHistory(Event.from_mixed_list(res))
+
+    def to_dataframe(self):
+        """
+        Experimental function to convert a list of events to DataFrame.
+        The `pandas` package is not, and will not, be a dependency of
+        the core `disruptive` package, but this may be a way of adding
+        significant convenience to the output format for data-science use.
+        May be removed in the future if we decide that this is not a good idea.
+
+        The columns `device_id`, `event_id`, and `event_type` is static, then
+        one additional column is added for every eventData field present.
+
+        Returns
+        -------
+        df : pandas.DataFrame
+            DataFrame of all events in response.
+
+        Raises
+        ------
+        ModueNotFoundError
+            If we pandas package is not installed.
+
+        """
+
+        try:
+            import pandas
+        except ModuleNotFoundError:
+            raise ModuleNotFoundError('Pandas not installed!')
+
+        rows = []
+        for event in self:
+            base = {
+                'device_id': event.device_id,
+                'event_id': event.event_id,
+                'event_type': event.event_type,
+            }
+
+            if event.event_type == disruptive.events.TEMPERATURE:
+                rows += [{
+                        **base,
+                        **sample.raw,
+                    } for sample in event.data.samples
+                ]
+            else:
+                rows.append({**base, **event.data.raw})
+
+        df = pandas.json_normalize(
+            rows, None, ['device_id', 'event_id', 'event_type'],
+            errors='ignore',
+        )
+
+        return df
+

--- a/disruptive/transforms.py
+++ b/disruptive/transforms.py
@@ -118,3 +118,7 @@ def _celsius_to_fahrenheit(celsius: float) -> float:
     """
 
     return (celsius * (9/5)) + 32
+
+
+def camel_to_snake_case(x: str) -> str:
+    return re.sub(r'(?<!^)(?=[A-Z])', '_', x).lower()

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,3 +54,6 @@ dev =
     pytest-cov>=2.11.1
     mypy>=0.812
     flake8>=3.9.0
+
+extra =
+    pandas >= 1.3.5, < 2.0.0

--- a/tests/test_eventhistory.py
+++ b/tests/test_eventhistory.py
@@ -1,3 +1,4 @@
+from typing import List
 from unittest import mock
 from dataclasses import dataclass
 
@@ -53,7 +54,7 @@ class TestEventHistory():
             name: str
             pandas_installed: bool
             give_events: disruptive.EventHistory
-            want_cols: list[str]
+            want_cols: List[str]
             want_len: int
 
         tests = [

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,10 +1,8 @@
-# Standard library imports
 from datetime import datetime, timezone, timedelta
+from dataclasses import dataclass
 
-# Third-party imports.
 import pytest
 
-# Project imports.
 import disruptive.transforms as dttrans
 import disruptive.errors as dterrors
 
@@ -100,3 +98,37 @@ class TestTransforms():
     def test_validate_iso8601_format_date_only(self):
         inp = '1970-01-01'
         assert dttrans.validate_iso8601_format(inp) is False
+
+    def test_camel_to_snake_case(self):
+        @dataclass
+        class TestCase:
+            name: str
+            give_str: str
+            want_str: str
+
+        tests = [
+            TestCase(
+                name='single case',
+                give_str='camelCase',
+                want_str='camel_case',
+            ),
+            TestCase(
+                name='multiple cases',
+                give_str='camelCaseDoesntBelongInPython',
+                want_str='camel_case_doesnt_belong_in_python',
+            ),
+            TestCase(
+                name='keep dots',
+                give_str='name.camelCase',
+                want_str='name.camel_case',
+            ),
+            TestCase(
+                name='keep spaces',
+                give_str='name and camelCase',
+                want_str='name and camel_case',
+            ),
+        ]
+
+        for test in tests:
+            snake_case = dttrans.camel_to_snake_case(test.give_str)
+            assert snake_case == test.want_str, test.name


### PR DESCRIPTION
## Overview
Experimental function to convert a list of events to DataFrame.
Requires the installation of additional packages.
> pip install disruptive[extra]

The `pandas` package is not, and will not, be a dependency of
the core `disruptive` package. However, supporting DataFrames is a
significant enough convenience that we're experimenting with it here.
May be removed in the future if we decide that this is not a good idea.

The columns `device_id`, `event_id`, and `event_type` are static, then
one additional column is concatenated for every eventData field.

---
## Changes to EventHistory.list_events()
**Before:**
`EventHistory.list_events()` output was `list[Event]`.

**Now:**
`EventHistory.list_events()` output is `EventHistory`, the instance of a class that itself inherits the `list` type. This allows us to add functionality like `to_dataframe()` while preserving all the previous behavior expected from a `list`.

For an `list_events()` output `events`, the check
```python
isinstance(events, list)
```
still holds and should not affect previous implementations.