### PR TITLE
feat: claim API support

### DIFF
--- a/disruptive/__init__.py
+++ b/disruptive/__init__.py
@@ -31,6 +31,7 @@ from disruptive.resources.eventhistory import EventHistory as EventHistory  # no
 from disruptive.resources.service_account import ServiceAccount as ServiceAccount  # noqa
 from disruptive.resources.role import Role as Role  # noqa
 from disruptive.resources.emulator import Emulator as Emulator  # noqa
+from disruptive.resources.claim import Claim as Claim  # noqa
 
 # Additional helper modules.
 from disruptive import events as events  # noqa

--- a/disruptive/errors.py
+++ b/disruptive/errors.py
@@ -255,6 +255,66 @@ class UnknownError(DTApiError):
         super().__init__(message)
 
 
+# -------------------------- ClaimErrors ---------------------------
+class ClaimError(DTApiError):
+    """
+    Covers errors related to claiming functions.
+    These are mostly captured requests exceptions.
+
+    """
+
+    def __init__(self, error: dict) -> None:
+        super().__init__(error)
+
+        # Unmodified API json response.
+        self.raw = error
+
+
+class ClaimErrorDeviceAlreadyClaimed(ClaimError):
+    """
+    The devices has already been claimed.
+
+    """
+
+    def __init__(self, error: dict) -> None:
+        # Inherit from ClaimError parent.
+        super().__init__(error)
+
+        self.device_id: str = error['deviceId']
+        self.code: str = error['code']
+        self.message: str = error['message']
+
+
+class ClaimErrorKitNotFound(ClaimError):
+    """
+    The kit was not found.
+
+    """
+
+    def __init__(self, error: dict) -> None:
+        # Inherit from ClaimError parent.
+        super().__init__(error)
+
+        self.kit_id: str = error['kitId']
+        self.code: str = error['code']
+        self.message: str = error['message']
+
+
+class ClaimErrorDeviceNotFound(ClaimError):
+    """
+    The device was not found.
+
+    """
+
+    def __init__(self, error: dict) -> None:
+        # Inherit from ClaimError parent.
+        super().__init__(error)
+
+        self.device_id: str = error['deviceId']
+        self.code: str = error['code']
+        self.message: str = error['message']
+
+
 # ------------------------- error handling -------------------------
 def parse_request_error(caught_error: Exception,
                         data: dict,

--- a/disruptive/resources/claim.py
+++ b/disruptive/resources/claim.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from typing import Any, Optional, List, Tuple
+
+import disruptive.outputs as dtoutputs
+import disruptive.requests as dtrequests
+import disruptive.errors as dterrors
+
+
+class Claim(dtoutputs.OutputBase):
+    """
+    Namespacing for claim methods.
+
+    """
+
+    KIT = 'KIT'
+    DEVICE = 'DEVICE'
+    CLAIM_ITEMS = [KIT, DEVICE]
+
+    def __init__(self, claim: dict) -> None:
+        """
+        Constructs the Claim object by unpacking raw claim response.
+
+        Parameters
+        ----------
+        claim : dict
+            Unmodified claim response dictionary.
+
+        """
+
+        # Inherit from OutputBase parent.
+        dtoutputs.OutputBase.__init__(self, claim)
+
+        # Unpack attributes from dictionary.
+        self.type: str = claim['type']
+        self.claimed_item: Claim.Kit | Claim.Device = self._resolve_type(claim)
+
+    @classmethod
+    def claim_info(cls, identifier: str, **kwargs: Any) -> Claim:
+        """
+        Get the claim information for either a kit or device.
+        The identifier can be found in the sensor QR code or
+        as an xid printed directly on the sensor.
+
+        Parameters
+        ----------
+        identifier : str
+            Unique ID of the target Device or Kit.
+
+        Returns
+        -------
+        claim : Device | Kit
+            Claim information about the requested Device or Kit.
+
+        Raises
+        ------
+        TypeError
+            If provided identifier is not str type.
+
+        """
+
+        if not isinstance(identifier, str):
+            raise TypeError(f'Identifier must be str, got {type(identifier)}.')
+
+        url = f':claim-info?identifier={identifier}'
+
+        return cls(dtrequests.DTRequest.get(url, **kwargs))
+
+    @staticmethod
+    def claim(project_id: str,
+              kit_ids: Optional[List[str]] = None,
+              device_ids: Optional[List[str]] = None,
+              dry_run: bool = False,
+              **kwargs: Any,
+              ) -> Tuple[List[Claim.Device], List[Exception]]:
+        """
+        Claim a number of kits and/or devices to your project.
+
+        Parameters
+        ----------
+        project_id : str
+            Unique identifier of target project.
+        kit_ids : list[str], optional
+            List of unique kit IDs to claim.
+        device_ids : list[str], optional
+            List of unique device IDs to claim.
+        dry_run : bool, optional
+            Test your claim request during development.
+            No kits or devices will be claimed.
+        **kwargs
+            Arbitrary keyword arguments.
+            See the :ref:`Configuration <configuration>` page.
+
+        Returns
+        -------
+        devices : list[Claim.Device]
+            List of successfully claimed devices.
+        errors : list[ClaimError]
+            List of errors that occured during claiming.
+            If list is empty, all devices were claimed successfully.
+
+        """
+
+        url = f'/projects/{project_id}/devices:claim'
+        url += f'?dryRun={str(dry_run).lower()}'
+
+        body = {}
+        if kit_ids is not None:
+            body['kitIds'] = kit_ids
+        if device_ids is not None:
+            body['deviceIds'] = device_ids
+
+        res = dtrequests.DTRequest.post(url, body=body, **kwargs)
+
+        return (
+            [Claim.Device(d) for d in res['claimedDevices']],
+            Claim._parse_claim_errors(res['claimErrors']),
+        )
+
+    @staticmethod
+    def _parse_claim_errors(res_errors: dict) -> List[Exception]:
+        errors: List[Exception] = []
+        for error in res_errors['devices'] + res_errors['kits']:
+            if error['code'] == 'ALREADY_CLAIMED':
+                errors.append(dterrors.ClaimErrorDeviceAlreadyClaimed(error))
+            elif error['code'] == 'NOT_FOUND' and 'deviceId' in error:
+                errors.append(dterrors.ClaimErrorDeviceNotFound(error))
+            elif error['code'] == 'NOT_FOUND' and 'kitId' in error:
+                errors.append(dterrors.ClaimErrorKitNotFound(error))
+            else:
+                errors.append(dterrors.ClaimError(error))
+        return errors
+
+    def _resolve_type(self, claim: dict) -> Claim.Kit | Claim.Device:
+        """
+        Return either Kit or Device depending on type.
+
+        Parameters
+        ----------
+        claim : dict
+            Unmodified claim response dictionary.
+
+        Returns
+        -------
+        claim_item : Claim.Kit | Claim.Device
+            Either a Kit or Device object depending on type.
+
+        """
+
+        if claim['type'] == Claim.KIT:
+            return Claim.Kit(claim['kit'])
+        elif claim['type'] == Claim.DEVICE:
+            return Claim.Device(claim['device'])
+        else:
+            raise KeyError(f'unknown claim type {claim["type"]}')
+
+    class Device(dtoutputs.OutputBase):
+        """
+        Namespacing type for a claimed device.
+
+        """
+
+        def __init__(self, device: dict) -> None:
+            """
+            Constructs the claimed Device object from raw response.
+
+            """
+
+            # Inherit from OutputBase parent.
+            dtoutputs.OutputBase.__init__(self, device)
+
+            # Unpack attributes from raw response dictionary.
+            self.device_id: str = device['deviceId']
+            self.device_type: str = device['deviceType']
+            self.product_number: str = device['productNumber']
+            self.is_claimed: bool = device['isClaimed']
+
+    class Kit(dtoutputs.OutputBase):
+        """
+        Namespacing type for a claimed kit.
+
+        """
+
+        def __init__(self, kit: dict) -> None:
+            """
+            Constructs the claimed Kit object from raw response.
+
+            """
+
+            # Inherit from OutputBase parent.
+            dtoutputs.OutputBase.__init__(self, kit)
+
+            # Unpack attributes from raw response dictionary.
+            self.kit_id: str = kit['kitId']
+            self.display_name: str = kit['displayName']
+            self.devices: List[Claim.Device] \
+                = [Claim.Device(d) for d in kit['devices']]

--- a/disruptive/resources/claim.py
+++ b/disruptive/resources/claim.py
@@ -11,6 +11,13 @@ class Claim(dtoutputs.OutputBase):
     """
     Namespacing for claim methods.
 
+    Attributes
+    ----------
+    type : str
+        Whether or not the claim is for a KIT or DEVICE.
+    claimed_item : Claim.Kit | Claim.Device
+        An object representing the kit or device claim.
+
     """
 
     KIT = 'KIT'
@@ -39,8 +46,11 @@ class Claim(dtoutputs.OutputBase):
     def claim_info(cls, identifier: str, **kwargs: Any) -> Claim:
         """
         Get the claim information for either a kit or device.
-        The identifier can be found in the sensor QR code or
-        as an xid printed directly on the sensor.
+
+        For sensors, the identifier can be found in either
+        the QR code or printed directly on the sensor.
+        For kits, the identifier can be found both as text
+        and a QR code printed on the box.
 
         Parameters
         ----------
@@ -158,6 +168,17 @@ class Claim(dtoutputs.OutputBase):
         """
         Namespacing type for a claimed device.
 
+        Attributes
+        ----------
+        device_id : str
+            Unique device identifier.
+        device_type : str
+            :ref:`Device type <device_type_constants>`.
+        product_number : str
+            The device product number.
+        is_claimed : bool
+            Whether or not the devices has been claimed.
+
         """
 
         def __init__(self, device: dict) -> None:
@@ -178,6 +199,15 @@ class Claim(dtoutputs.OutputBase):
     class Kit(dtoutputs.OutputBase):
         """
         Namespacing type for a claimed kit.
+
+        Attributes
+        ----------
+        kit_id : str
+            Unique kit identifier.
+        display_name : str
+            Human reabable kit name.
+        devices : list[Claim.Device]
+            List of devices in the kit.
 
         """
 

--- a/tests/api_responses.py
+++ b/tests/api_responses.py
@@ -955,3 +955,139 @@ batch_label_response = {
         }
     ]
 }
+
+claim_error_device_already_claimed = {
+    'deviceId': 'b',
+    'code': 'ALREADY_CLAIMED',
+    'message': 'The device was previously claimed',
+}
+
+claim_error_device_not_found = {
+    'deviceId': 'c',
+    'code': 'NOT_FOUND',
+    'message': 'The device was not found',
+}
+
+claim_error_kit_not_found = {
+    'kitId': 'd',
+    'code': 'NOT_FOUND',
+    'message': 'The kit was not found',
+}
+
+claimed_devices = {
+    'claimedDevices': [
+        {
+            'deviceId': 'a',
+            'deviceType': 'temperature',
+            'productNumber': 'a',
+            'isClaimed': True,
+        },
+        {
+            'deviceId': 'b',
+            'deviceType': 'temperature',
+            'productNumber': 'b',
+            'isClaimed': True,
+        },
+    ],
+    'claimErrors': {
+        'devices': [],
+        'kits': [],
+    }
+}
+
+claimed_device_already_claimed = {
+    'claimedDevices': [
+        {
+            'deviceId': 'a',
+            'deviceType': 'temperature',
+            'productNumber': 'a',
+            'isClaimed': True,
+        },
+    ],
+    'claimErrors': {
+        'devices': [
+            claim_error_device_already_claimed,
+        ],
+        'kits': [],
+    }
+}
+
+claimed_device_not_found = {
+    'claimedDevices': [
+        {
+            'deviceId': 'a',
+            'deviceType': 'temperature',
+            'productNumber': 'a',
+            'isClaimed': True,
+        },
+    ],
+    'claimErrors': {
+        'devices': [
+            claim_error_device_not_found,
+        ],
+        'kits': [],
+    }
+}
+
+claimed_kit_not_found = {
+    'claimedDevices': [
+        {
+            'deviceId': 'a',
+            'deviceType': 'temperature',
+            'productNumber': 'a',
+            'isClaimed': True,
+        },
+    ],
+    'claimErrors': {
+        'devices': [],
+        'kits': [claim_error_kit_not_found],
+    }
+}
+
+claim_info_kit = {
+    'type': 'KIT',
+    'kit': {
+        'kitId': 'fff000',
+        'displayName': 'Starter Kit EU, 5 sensors',
+        'sensors': {
+            'totalCount': 5,
+            'claimedCount': 0,
+        },
+        'cloudConnectors': {
+            'totalCount': 1,
+            'claimedCount': 0,
+        },
+        'devices': [
+            {
+                'deviceId': 'a',
+                'deviceType': 'touch',
+                'productNumber': '',
+                'isClaimed': True,
+            },
+            {
+                'deviceId': 'b',
+                'deviceType': 'proximity',
+                'productNumber': '',
+                'isClaimed': True,
+             },
+            {
+                'deviceId': 'c',
+                'deviceType': 'temperature',
+                'productNumber': '',
+                'isClaimed': True,
+            },
+            {
+                'deviceId': 'd',
+                'deviceType': 'proximity',
+                'productNumber': '',
+                'isClaimed': True,
+            },
+            {
+                'deviceId': 'e',
+                'deviceType': 'temperature',
+                'productNumber': '',
+                'isClaimed': True,
+            },
+        ],
+    },
+}

--- a/tests/test_claim.py
+++ b/tests/test_claim.py
@@ -1,0 +1,186 @@
+from dataclasses import dataclass
+from typing import List, Any
+
+import pytest
+
+import disruptive
+import disruptive.errors as dterrors
+import tests.api_responses as dtapiresponses
+
+
+class TestClaim():
+
+    def test_claim(self, request_mock):
+        @dataclass
+        class TestCase:
+            name: str
+            give_project_id: str
+            give_device_ids: List[str]
+            give_kit_ids: List[str]
+            give_dry_run: bool
+            give_res: dict
+            want_device_ids: List[str]
+            want_error: Any
+
+        tests = [
+            TestCase(
+                name='claim devices',
+                give_project_id='p1',
+                give_device_ids=['a', 'b'],
+                give_kit_ids=[],
+                give_dry_run=False,
+                give_res=dtapiresponses.claimed_devices,
+                want_device_ids=['a', 'b'],
+                want_error=None,
+            ),
+            TestCase(
+                name='claim kits',
+                give_project_id='p1',
+                give_device_ids=[],
+                give_kit_ids=['k1'],
+                give_dry_run=False,
+                give_res=dtapiresponses.claimed_devices,
+                want_device_ids=['a', 'b'],
+                want_error=None,
+            ),
+            TestCase(
+                name='device already claimed',
+                give_project_id='p1',
+                give_device_ids=['a'],
+                give_kit_ids=[],
+                give_dry_run=False,
+                give_res=dtapiresponses.claimed_device_already_claimed,
+                want_device_ids=['a'],
+                want_error=dterrors.ClaimErrorDeviceAlreadyClaimed,
+            ),
+            TestCase(
+                name='device not found',
+                give_project_id='p1',
+                give_device_ids=['a'],
+                give_kit_ids=[],
+                give_dry_run=False,
+                give_res=dtapiresponses.claimed_device_not_found,
+                want_device_ids=['a'],
+                want_error=dterrors.ClaimErrorDeviceNotFound,
+            ),
+            TestCase(
+                name='kit not found',
+                give_project_id='p1',
+                give_device_ids=[],
+                give_kit_ids=['a'],
+                give_dry_run=False,
+                give_res=dtapiresponses.claimed_kit_not_found,
+                want_device_ids=['a'],
+                want_error=dterrors.ClaimErrorKitNotFound,
+            ),
+        ]
+
+        for test in tests:
+            request_mock.json = test.give_res
+            devices, errors = disruptive.Claim.claim(
+                project_id=test.give_project_id,
+                kid_ids=test.give_kit_ids,
+                device_ids=test.give_device_ids,
+                dry_run=test.give_dry_run,
+            )
+
+            for i in range(len(devices)):
+                assert devices[i].device_id == test.want_device_ids[i], \
+                    test.name
+
+                for error in errors:
+                    if test.want_error is not None:
+                        assert isinstance(error, test.want_error), test.name
+                        with pytest.raises(test.want_error):
+                            raise error
+                    else:
+                        assert len(errors) == 0, test.name
+
+    def test_claim_info(self, request_mock):
+        @dataclass
+        class TestCase:
+            name: str
+            give_identifier: str
+            give_res: dict
+            want_err: Any
+
+        tests = [
+            TestCase(
+                name='test 1',
+                give_identifier='id1',
+                give_res=dtapiresponses.claim_info_kit,
+                want_err=None,
+            ),
+            TestCase(
+                name='identifier type conflict',
+                give_identifier=99,
+                give_res={},
+                want_err=TypeError,
+            ),
+        ]
+
+        for test in tests:
+            request_mock.json = test.give_res
+
+            if test.want_err is None:
+                claim = disruptive.Claim.claim_info(test.give_identifier)
+                assert isinstance(claim, disruptive.Claim), test.name
+            else:
+                with pytest.raises(test.want_err):
+                    disruptive.Claim.claim_info(test.give_identifier)
+
+    def test_claim_errors(self):
+        @dataclass
+        class TestCase:
+            name: str
+            give_res: dict
+            want_err: Any
+
+        tests = [
+            TestCase(
+                name='unknown code ClaimError',
+                give_res={
+                    'devices': [{'code': 'UNKNOWN_CODE'}],
+                    'kits': [{'code': 'UNKNOWN_CODE'}],
+                },
+                want_err=dterrors.ClaimError,
+            ),
+            TestCase(
+                name='device already claimed',
+                give_res={
+                    'devices': [
+                        dtapiresponses.claim_error_device_already_claimed,
+                    ],
+                    'kits': [],
+                },
+                want_err=dterrors.ClaimErrorDeviceAlreadyClaimed,
+            ),
+            TestCase(
+                name='device not found',
+                give_res={
+                    'devices': [
+                        dtapiresponses.claim_error_device_not_found,
+                    ],
+                    'kits': [],
+                },
+                want_err=dterrors.ClaimErrorDeviceNotFound,
+            ),
+            TestCase(
+                name='kit not found',
+                give_res={
+                    'devices': [],
+                    'kits': [
+                        dtapiresponses.claim_error_kit_not_found,
+                    ],
+                },
+                want_err=dterrors.ClaimErrorKitNotFound,
+            ),
+        ]
+
+        for test in tests:
+            errors = disruptive.Claim._parse_claim_errors(test.give_res)
+            for error in errors:
+                assert isinstance(error, dterrors.ClaimError), test.name
+                assert isinstance(error, test.want_err), test.name
+                with pytest.raises(test.want_err):
+                    raise error


### PR DESCRIPTION
Implementation of our new REST API Claim functionality, containing a new namespace `Claim` with two new methods.
- `disruptive.Claim.claim()`
- `disruptive.Claim.claim_info()`
