### PR TITLE
fix: /v2/:claim-info redirected to /v2/claimInfo

### DIFF
--- a/disruptive/resources/claim.py
+++ b/disruptive/resources/claim.py
@@ -87,7 +87,7 @@ class Claim(dtoutputs.OutputBase):
         if not isinstance(identifier, str):
             raise TypeError(f'Identifier must be str, got {type(identifier)}.')
 
-        url = f':claim-info?identifier={identifier}'
+        url = f'/claimInfo?identifier={identifier}'
 
         return cls(dtrequests.DTRequest.get(url, **kwargs))
 


### PR DESCRIPTION
Related to REST API Changelog `2022-11-04`.