### PR TITLE
fix: raise unhandled request error directly

### DIFF
--- a/disruptive/errors.py
+++ b/disruptive/errors.py
@@ -359,8 +359,8 @@ def parse_request_error(caught_error: Exception,
             nth_attempt**2,
         )
     else:
-        # Uncategorized error has been raised.
-        return UnknownError(data), False, None
+        # Unhandled error has been raised.
+        return caught_error, False, None
 
 
 def parse_api_status_code(status_code: Optional[int],

--- a/tests/test_requests.py
+++ b/tests/test_requests.py
@@ -312,7 +312,7 @@ class TestRequests():
         )
 
         # Catch the expected ConnectionError that should be raised.
-        with pytest.raises(disruptive.errors.UnknownError):
+        with pytest.raises(requests.exceptions.RequestException):
             # Call Device.get_device(), overriden all defaults with kwargs.
             _ = disruptive.Device.get_device(
                 device_id='device_id',
@@ -327,7 +327,7 @@ class TestRequests():
         )
 
         # Catch the expected ConnectionError that should be raised.
-        with pytest.raises(disruptive.errors.UnknownError):
+        with pytest.raises(requests.exceptions.RequestException):
             # Call Device.get_device(), overriden all defaults with kwargs.
             _ = disruptive.Device.get_device(
                 device_id='device_id',


### PR DESCRIPTION
Wrapping unhandled errors in `UnknownError` caused more problems than it solved, so we're changing this behavior. It should not be much easier to see what went wrong if an unhandled error is raised.