### PR TITLE
fix: missing motion device constant

### DIFF
--- a/disruptive/resources/device.py
+++ b/disruptive/resources/device.py
@@ -50,11 +50,12 @@ class Device(dtoutputs.OutputBase):
     WATER_DETECTOR = 'waterDetector'
     CLOUD_CONNECTOR = 'ccon'
     CO2 = 'co2'
+    MOTION = 'motion'
     DESK_OCCUPANCY = 'deskOccupancy'
     DEVICE_TYPES = [
         TEMPERATURE, PROXIMITY, TOUCH, HUMIDITY,
         PROXIMITY_COUNTER, TOUCH_COUNTER, WATER_DETECTOR,
-        CLOUD_CONNECTOR, CO2, DESK_OCCUPANCY,
+        CLOUD_CONNECTOR, CO2, MOTION, DESK_OCCUPANCY,
     ]
 
     def __init__(self, device: dict) -> None:

--- a/tests/api_responses.py
+++ b/tests/api_responses.py
@@ -852,6 +852,19 @@ co2_event = {
     "timestamp": "2022-01-27T15:50:34.471000Z"
 }
 
+motion_event = {
+    'eventId': '9j53ftiet8nog4fac7ug',
+    'targetName': 'projects/ci429ep0vlodur6n23f0/devices/emucj4fj3epdjrin69t0v80',
+    'eventType': 'motion',
+    'data': {
+        'motion': {
+            'state': 'MOTION_DETECTED',
+            'updateTime': '2023-08-02T11:03:18.595777Z',
+        },
+    },
+    'timestamp': '2023-08-02T11:03:18.595777Z',
+}
+
 pressure_event = {
     "eventId": "c0pbuiurq6u6ltshi151",
     "targetName": "projects/c75ivl3go7df88ctp0ug/devices/u6sfppl7rihg0dm4ud7s",
@@ -882,6 +895,7 @@ event_history_each_type = {
         ethernet_status_event,
         cellular_status_event,
         co2_event,
+        motion_event,
         pressure_event,
     ]
 }

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -382,6 +382,7 @@ class TestDevice():
             dtapiresponses.ethernet_status_event,
             dtapiresponses.cellular_status_event,
             dtapiresponses.co2_event,
+            dtapiresponses.motion_event,
             dtapiresponses.pressure_event,
         ]
 


### PR DESCRIPTION
- Added missing constant `disruptive.Device.MOTION`.
- Added motion event to tests.