### PR TITLE
support for listing all org devices

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
 
 import disruptive
+import disruptive.errors as dterrors
 import disruptive.events.events as dtevents
 import tests.api_responses as dtapiresponses
-import disruptive.errors as dterrors
 
 
 class TestDevice():
@@ -88,7 +88,7 @@ class TestDevice():
         request_mock.assert_request_count(1)
 
         # output should be list.
-        assert type(devices) == list
+        assert isinstance(devices, list)
 
         # Assert output is list of Device.
         for d in devices:
@@ -126,7 +126,7 @@ class TestDevice():
         request_mock.assert_request_count(1)
 
         # output should be list.
-        assert type(devices) == list
+        assert isinstance(devices, list)
 
         # Assert output is list of Device.
         for d in devices:


### PR DESCRIPTION
Backwards compatible with no breaking changes.

## New Behavior
- If `project_id` is provided as wildcard `"-"`, new parameter `organization_id` is required and will result in a list of devices that the user has access to from the entire organization.
- The new parameter `project_ids` is optional if `project_id` is wildcard and can be used to filter from which projects devices are listed.
- Unsupported combinations of parameters will either raise an exception or warning depending on severity.